### PR TITLE
Support for Template Inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,71 @@ $blade = $blade = new Blade(__DIR__, __DIR__ . '/.cache');
 echo $blade->render('hello', ['name' => 'Jhon Doe']);
 ```
 
+## Layouts
+
+### Template Inheritance - ✅
+
+Template inheritance allows you to create layouts by defining a master template that can be extended by child templates.
+
+```blade
+{{-- layouts/app.blade.php --}}
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>App Name - @yield('title')</title>
+    </head>
+    <body>
+        <main>
+            @yield('content')
+        </main>
+        <aside>
+            @yield('sidebar')
+        </aside>
+    </body>
+</html>
+```
+
+```blade
+{{-- blog-post.blade.php --}}
+
+@extends('layouts.app')
+
+@section('title', 'Home Page')
+
+@section('content')
+    <article>
+        <h1>Blog Post</h1>
+        <p>This is the blog post content.</p>
+    </article>
+@endsection
+
+@section('sidebar')
+    @parent
+
+    <h3>Related Posts</h3>
+    <ul>
+        <li>Post 1</li>
+        <li>Post 2</li>
+        <li>Post 3</li>
+    </ul>
+@endsection
+```
+
+#### Supported Directives
+
+| Directive         | Description                                    | Status |
+| ----------------- | ---------------------------------------------- | ------ |
+| `@extends`        | Directive to extend layout                     | ✅     |
+| `@yield`          | Outputs a section content                      | ✅     |
+| `@section`        | Defines a section content                      | ✅     |
+| `@endsection`     | Defined a end of section content               | ✅     |
+| `@show`           | Outputs a section content immediately          | ✅     |
+| `@parent`         | Outputs the content of the parent section      | ✅     |
+| `@hasSection`     | Determines if section content has been defined | ✅     |
+| `@sectionMissing` | Determines if section content is missing       | ✅     |
+
+
 ## Feature List
 
 ### Blade Directives
@@ -93,16 +158,14 @@ echo $blade->render('hello', ['name' => 'Jhon Doe']);
 | `{{ $attributes->get() }}`                           |             | ✅     |
 | `Default {{ $slot }}`                                |             | ✅     |
 | `Name slots {{ $customSlot }}`                       |             | ✅     |
-| `$slot->isEmpty()`                                   |             | ❌     |
+| `$slot->isEmpty()`                                   |             | ✅     |
 | `$slot->hasActualContent()`                          |             | ❌     |
-| `$slot->isEmpty()`                                   |             | ❌     |
-| `$slot->isEmpty()`                                   |             | ❌     |
 | `Scoped Slots`                                       |             | ❌     |
 | `Slot Attributes`                                    |             | ❌     |
 | `Dynamic Components`                                 |             | ❌     |
 | `Anonymous Index Components`                         |             | ❌     |
 
-### Templating
+### Directives
 
 | Directive         | Description | Status |
 | ----------------- | ----------- | ------ |
@@ -110,8 +173,6 @@ echo $blade->render('hello', ['name' => 'Jhon Doe']);
 | `@guest`          |             | ❌     |
 | `@production`     |             | ❌     |
 | `@env`            |             | ❌     |
-| `@hasSection`     |             | ❌     |
-| `@sectionMissing` |             | ❌     |
 | `@include`        |             | ❌     |
 | `@session`        |             | ❌     |
 | `@checked`        |             | ❌     |

--- a/src/Blade.php
+++ b/src/Blade.php
@@ -5,10 +5,12 @@ namespace Blade;
 final class Blade
 {
     public ComponentRenderer $componentRenderer;
+    public TemplateInheritanceRenderer $templateRenderer;
 
     public function __construct(protected string $viewPath, protected string $cachePath)
     {
         $this->componentRenderer = new ComponentRenderer($this);
+        $this->templateRenderer = new TemplateInheritanceRenderer($this);
     }
 
 
@@ -38,6 +40,7 @@ final class Blade
         extract($data);
 
         $component_renderer = $this->componentRenderer;
+        $template_renderer = $this->templateRenderer;
 
         include $this->getCachedViewPath($this->compile($view));;
     }

--- a/src/CompileAtRules.php
+++ b/src/CompileAtRules.php
@@ -73,7 +73,7 @@ class CompileAtRules
             $this->content = $this->compileDirective($directive, $this->content);
         }
 
-        if($this->usesTemplateInheritance){
+        if ($this->usesTemplateInheritance) {
             $this->content .= $this->endExtends();
         }
 
@@ -317,5 +317,15 @@ class CompileAtRules
     protected function compileEndsection(string $expression): string
     {
         return "<?php \$template_renderer->endSection(); ?>";
+    }
+
+    protected function compileShow(string $expression): string
+    {
+        return "<?php echo \$template_renderer->outputSection(); ?>";
+    }
+
+    protected function compileParent(string $expression): string
+    {
+        return "### DEFAULT SECTION CONTENT ###";
     }
 }

--- a/src/CompileAtRules.php
+++ b/src/CompileAtRules.php
@@ -333,4 +333,9 @@ class CompileAtRules
     {
         return "<?php if(\$template_renderer->hasSection{$expression}): ?>";
     }
+
+    protected function compileSectionMissing(string $expression): string
+    {
+        return "<?php if(!\$template_renderer->hasSection{$expression}): ?>";
+    }
 }

--- a/src/CompileAtRules.php
+++ b/src/CompileAtRules.php
@@ -17,7 +17,7 @@ class CompileAtRules
 
     public function compile(): string
     {
-        $statementRegex = "/(@|)@(?'directive'[a-z]+)\s*(?'expression'\((?:\s|.)*?\))?/";
+        $statementRegex = "/(@|)@(?'directive'[a-z]+)\s*(?'expression'\((?:\s|.)*?\))?/i";
 
         $matches = [];
 
@@ -327,5 +327,10 @@ class CompileAtRules
     protected function compileParent(string $expression): string
     {
         return "### DEFAULT SECTION CONTENT ###";
+    }
+
+    protected function compileHasSection(string $expression): string
+    {
+        return "<?php if(\$template_renderer->hasSection{$expression}): ?>";
     }
 }

--- a/src/CompileAtRules.php
+++ b/src/CompileAtRules.php
@@ -8,6 +8,7 @@ class CompileAtRules
 
     protected bool $switchOpen = false;
     protected bool $switchFirstCaseClosed = false;
+    protected bool $usesTemplateInheritance = false;
 
     public function __construct(protected string $content)
     {
@@ -70,6 +71,10 @@ class CompileAtRules
             }
 
             $this->content = $this->compileDirective($directive, $this->content);
+        }
+
+        if($this->usesTemplateInheritance){
+            $this->content .= $this->endExtends();
         }
 
         return $this->content;
@@ -285,5 +290,32 @@ class CompileAtRules
     protected function compileEndwhile(string $expression): string
     {
         return "<?php endwhile; ?>";
+    }
+
+    protected function compileExtends(string $expression): string
+    {
+        $this->usesTemplateInheritance = true;
+
+        return "<?php \$template_renderer->extends({$expression}); ?>";
+    }
+
+    protected function endExtends(): string
+    {
+        return "<?php \$template_renderer->output(); ?>";
+    }
+
+    protected function compileYield(string $expression): string
+    {
+        return "<?php echo \$template_renderer->yield{$expression}; ?>";
+    }
+
+    protected function compileSection(string $expression): string
+    {
+        return "<?php \$template_renderer->startSection{$expression}; ?>";
+    }
+
+    protected function compileEndsection(string $expression): string
+    {
+        return "<?php \$template_renderer->endSection(); ?>";
     }
 }

--- a/src/TemplateInheritanceRenderer.php
+++ b/src/TemplateInheritanceRenderer.php
@@ -28,9 +28,11 @@ class TemplateInheritanceRenderer
         return  $fallbackContent;
     }
 
-    public function startSection(string $section): void
+    public function startSection(string $section, string $inlineContent = ''): void
     {
-        ob_start();
+        if (!$inlineContent) {
+            ob_start();
+        }
 
         $this->currentSection = $section;
 
@@ -39,7 +41,7 @@ class TemplateInheritanceRenderer
         }
 
         $this->sections[$section] = (object) [
-            'content' => '',
+            'content' => $inlineContent ? $inlineContent : '',
             'defaultContent' => '',
         ];
     }

--- a/src/TemplateInheritanceRenderer.php
+++ b/src/TemplateInheritanceRenderer.php
@@ -56,7 +56,7 @@ class TemplateInheritanceRenderer
         }
     }
 
-    protected function hasSection(string $section): bool
+    public function hasSection(string $section): bool
     {
         return isset($this->sections[$section]);
     }

--- a/src/TemplateInheritanceRenderer.php
+++ b/src/TemplateInheritanceRenderer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Blade;
+
+class TemplateInheritanceRenderer
+{
+    protected string $template = '';
+    protected array $sections = [];
+
+    public function __construct(protected Blade $blade)
+    {
+    }
+
+    public function extends(string $template): void
+    {
+        $this->template = $template;
+        ob_start();
+    }
+
+    public function yield(string $section, string $fallbackContent = ''): string
+    {
+        if ($this->hasSection($section)) {
+            return $this->getSection($section);
+        }
+
+        return  $fallbackContent;
+    }
+
+    public function startSection(string $section): void
+    {
+        ob_start();
+
+        $this->sections[$section] = null;
+    }
+
+    public function endSection(): void
+    {
+        $this->sections[array_key_last($this->sections)] = ob_get_clean();
+    }
+
+    protected function hasSection(string $section): bool
+    {
+        return isset($this->sections[$section]);
+    }
+
+    protected function getSection(string $section): string
+    {
+        return $this->sections[$section];
+    }
+
+    public function output(): void
+    {
+        $output = ob_get_clean();
+        if (trim($output) !== '') {
+            echo $output;
+        }
+
+        echo $this->blade->render($this->template);
+    }
+}

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -205,4 +205,22 @@ class TemplateInheritanceTest extends TestCase
             )
         );
     }
+
+    public function testSectionMissing(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(
+                self::LAYOUT,
+                "Content Before @sectionMissing('content') Default Content @endif After Content"
+            ),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, "Content Before  Default Content After Content"),
+            $this->renderBlade(
+                "@extends('layout')"
+            )
+        );
+    }
 }

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace  Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class TemplateInheritanceTest extends TestCase
+{
+    use VerifiesOutputTrait;
+
+    public function testOnlyExtends()
+    {
+        $layout = <<<LAYOUT
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Layout</title>
+        </head>
+        <body>
+        </body>
+        </html>
+        LAYOUT;
+
+        $this->createTemporaryBladeFile($layout, 'layout');
+
+        $this->assertSame(
+            $layout,
+            $this->renderBlade('@extends("layout")')
+        );
+    }
+
+
+    public function testYieldWithDefaultContent(): void
+    {
+
+        $layout = <<<LAYOUT
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Layout</title>
+        </head>
+        <body>%s</body>
+        </html>
+        LAYOUT;
+
+        $this->createTemporaryBladeFile(
+            sprintf($layout, "@yield('content', 'Default Content')"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf($layout, "Default Content"),
+            $this->renderBlade('@extends("layout")')
+        );
+    }
+
+    public function testYieldWithSection(): void
+    {
+        $layout = <<<LAYOUT
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Layout</title>
+        </head>
+        <body>%s</body>
+        </html>
+        LAYOUT;
+
+        $this->createTemporaryBladeFile(
+            sprintf($layout, "@yield('content')"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf($layout, " Section Content "),
+            $this->renderBlade('@extends("layout") @section("content") Section Content @endsection')
+        );
+    }
+}

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -21,22 +21,10 @@ class TemplateInheritanceTest extends TestCase
 
     public function testOnlyExtends()
     {
-        $layout = <<<LAYOUT
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <title>Layout</title>
-        </head>
-        <body>
-        </body>
-        </html>
-        LAYOUT;
-
-        $this->createTemporaryBladeFile($layout, 'layout');
+        $this->createTemporaryBladeFile(self::LAYOUT, 'layout');
 
         $this->assertSame(
-            $layout,
+            self::LAYOUT,
             $this->renderBlade('@extends("layout")')
         );
     }
@@ -44,49 +32,26 @@ class TemplateInheritanceTest extends TestCase
 
     public function testYieldWithDefaultContent(): void
     {
-
-        $layout = <<<LAYOUT
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <title>Layout</title>
-        </head>
-        <body>%s</body>
-        </html>
-        LAYOUT;
-
         $this->createTemporaryBladeFile(
-            sprintf($layout, "@yield('content', 'Default Content')"),
+            sprintf(self::LAYOUT, "@yield('content', 'Default Content')"),
             'layout'
         );
 
         $this->assertSame(
-            sprintf($layout, "Default Content"),
+            sprintf(self::LAYOUT, "Default Content"),
             $this->renderBlade('@extends("layout")')
         );
     }
 
     public function testYieldWithSection(): void
     {
-        $layout = <<<LAYOUT
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <title>Layout</title>
-        </head>
-        <body>%s</body>
-        </html>
-        LAYOUT;
-
         $this->createTemporaryBladeFile(
-            sprintf($layout, "@yield('content')"),
+            sprintf(self::LAYOUT, "@yield('content')"),
             'layout'
         );
 
         $this->assertSame(
-            sprintf($layout, " Section Content "),
+            sprintf(self::LAYOUT, " Section Content "),
             $this->renderBlade('@extends("layout") @section("content") Section Content @endsection')
         );
     }

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -8,6 +8,17 @@ class TemplateInheritanceTest extends TestCase
 {
     use VerifiesOutputTrait;
 
+    public const LAYOUT = <<<LAYOUT
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Layout</title>
+        </head>
+        <body>%s</body>
+        </html>
+        LAYOUT;
+
     public function testOnlyExtends()
     {
         $layout = <<<LAYOUT
@@ -79,4 +90,102 @@ class TemplateInheritanceTest extends TestCase
             $this->renderBlade('@extends("layout") @section("content") Section Content @endsection')
         );
     }
+
+    public function testSectionDoesntOutputByDefault(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(self::LAYOUT, "@section('content') It should show @endsection"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, ""),
+            $this->renderBlade('@extends("layout")')
+        );
+    }
+
+    public function testShowDirectiveSectionOutput(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(self::LAYOUT, "@section('content') It should show @show"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, " It should show "),
+            $this->renderBlade('@extends("layout")')
+        );
+    }
+
+    public function testDefaultSectionOverride(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(self::LAYOUT, "@section('content') Default Content @show"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, " Section Content "),
+            $this->renderBlade('@extends("layout") @section("content") Section Content @endsection')
+        );
+    }
+
+    public function testParentRule(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(self::LAYOUT, "@section('content') Default Content @show"),
+            'layout'
+        );
+
+        $this->assertSame(
+            $this->removeIndentation(
+                sprintf(self::LAYOUT, " Default Content Section Content ")
+            ),
+            $this->removeIndentation(
+                $this->renderBlade(
+                    "@extends('layout') @section('content') @parent Section Content @endsection"
+                )
+            )
+        );
+    }
+
+    public function testMultipleSections(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(
+                self::LAYOUT,
+                "@section('content') Default Content @show @section('footer') Footer @show"
+            ),
+            'layout'
+        );
+
+
+        $blade = "@extends('layout') " .
+            "@section('content') Section Content @endsection " .
+            "@section('footer') Footer Override @endsection";
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, " Section Content  Footer Override "),
+            $this->renderBlade($blade)
+        );
+    }
+
+    public function testMultipleSectionsWithDefaultContent(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(
+                self::LAYOUT,
+                "@section('content') Default Content @show @section('footer') Default Footer @show"
+            ),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, " Section Content  Default Footer "),
+            $this->renderBlade(
+                "@extends('layout') @section('content') Section Content @endsection"
+            )
+        );
+    }
+
 }

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -56,6 +56,32 @@ class TemplateInheritanceTest extends TestCase
         );
     }
 
+    public function testInlineSectionDirective(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(self::LAYOUT, "@yield('content')"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, "Section Content"),
+            $this->renderBlade("@extends('layout') @section('content', 'Section Content')")
+        );
+    }
+
+    public function testInlineSectionDirectiveWithShow(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(self::LAYOUT, "@section('content')@show"),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, "Section Content"),
+            $this->renderBlade("@extends('layout') @section('content', 'Section Content')")
+        );
+    }
+
     public function testSectionDoesntOutputByDefault(): void
     {
         $this->createTemporaryBladeFile(

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -188,4 +188,21 @@ class TemplateInheritanceTest extends TestCase
         );
     }
 
+    public function testHasSection(): void
+    {
+        $this->createTemporaryBladeFile(
+            sprintf(
+                self::LAYOUT,
+                "@hasSection('content') Default Content @yield('content') @endif"
+            ),
+            'layout'
+        );
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, " Default Content  Section Content  "),
+            $this->renderBlade(
+                "@extends('layout') @section('content') Section Content @endsection"
+            )
+        );
+    }
 }


### PR DESCRIPTION
Update aims to add support for building layouts using template inheritance as defined in the [Laravel 11x docs](https://laravel.com/docs/11.x/blade#layouts-using-template-inheritance)

**Support Requirements**
- [x] `@extends` directive
- [x] `@yield('section-name')` directive
- [x] `@yield('section-name', 'default-content')` directive
- [x] `@section('section-name') .... @endsection` section block directive
- [x] `@section('section-name', 'content`) Inline section directive 
- [x] `@parent` Renders content of parent section
- [x] `@show` Immediately output a section.
- [x] `@hasSection` directive
- [x] `@sectionMissing` directive