### PR TITLE
Component Attribute Bag Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ Template inheritance allows you to create layouts by defining a master template 
 | `{{ $attributes->merge() }}`                         |             | ✅     |
 | `{{ $attributes->class() }}`                         |             | ✅     |
 | `{{ $attributes->class() }} Conditional`             |             | ✅     |
-| `{{ $attributes->prepends() }}`                      |             | ❌     |
-| `{{ $attributes->filter() }}`                        |             | ❌     |
-| `{{ $attributes->whereStartsWith() }}`               |             | ❌     |
-| `{{ $attributes->whereDoesntStartWith() }}`          |             | ❌     |
-| `{{ $attributes->whereDoesntStartWith()->first() }}` |             | ❌     |
+| `{{ $attributes->prepends() }}`                      |             | ✅     |
+| `{{ $attributes->filter() }}`                        |             | ✅     |
+| `{{ $attributes->whereStartsWith() }}`               |             | ✅     |
+| `{{ $attributes->whereDoesntStartWith() }}`          |             | ✅     |
+| `{{ $attributes->whereDoesntStartWith()->first() }}` |             | ✅     |
 | `{{ $attributes->has() }}`                           |             | ✅     |
 | `{{ $attributes->hasAny() }}`                        |             | ✅     |
 | `{{ $attributes->get() }}`                           |             | ✅     |

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,101 @@
+# Components
+
+Components provide a way to create reusable elements that can be used in multiple places in your application, in Katana they look and act like html tags. Currently, Katana only supports anynomous components which are simple blade template files, but in the future, Katana will support class components which will be more powerful and flexible.
+
+## Creating a component
+
+To create a component, you need to create a blade template file in the inside `components` directory of your `views` directory. The file name should be the name of the component with the `.blade.php` extension. For example, if you want to create a component called `button`, you should create a file called `button.blade.php`.
+
+Here is an example of a simple component:
+
+```blade
+{{-- components/button.blade.php --}}
+<button> Simple </button>
+
+{{-- Using button --}}
+<x-button></x-button> or <x-button/>
+```
+
+## Passing data to components
+
+On its own, a component is just a static element, but you can pass data to a component using attributes. Here is an example of a component that accepts a `name` attribute:
+
+```blade
+{{-- components/alert.blade.php --}}
+
+<div class="alert alert-{{ $type }}">
+    {{ $message }}
+</div>
+
+{{-- Using alert --}}
+
+<x-alert type="info" message="Hello world"/>
+```
+
+### Passing Variables
+
+You can pass variables to components using the `:variable` syntax. Here is an example:
+
+```blade
+{{-- components/alert.blade.php --}}
+
+<div class="alert alert-{{ $type }}">
+    {{ $message }}
+</div>
+
+{{-- Using alert --}}
+@php
+    $message = "Hello world";
+    $type = "info";
+@endphp
+
+<x-alert :type="$type" :message="$message"/>
+```
+
+> [!Info]
+> Variables with multiple words should be separated by a dash `-` in the component tag. For example, `alert-type` instead of `alertType`.
+
+> [!Info]
+> Multiple word attributes are converted to camelCase in the component file. For example, `alert-type` will be accessible using `$alertType` in the component file.
+
+### Default values
+
+You can set default values for attributes in a component using the `@props` directive. Here is an example:
+
+```blade
+{{-- components/alert.blade.php --}}
+@props(['alertType' => 'info', 'message'])
+
+
+<div class="alert alert-{{ $alertType }}">
+    {{ $message }}
+</div>
+
+{{-- Using alert --}}
+<x-alert message="Hello world"/>
+```
+
+### Component Attributes
+
+You can access all the attributes passed to a component using the `$attributes` variable. Here is an example:
+
+```blade
+{{-- components/alert.blade.php --}}
+
+<div {{ $attributes->merge(['class' => 'alert alert-'.$type]) }}>
+    {{ $message }}
+</div>
+
+{{-- Using alert --}}
+<x-alert type="info" message="Hello world" class="mt-4"/>
+``
+```
+
+#### Attributes methods
+
+- `merge(array $defaultAttributes)`: Merges the given array with the component's attributes.
+- `except(array $keys)`: Remove the given keys from the component's attributes.
+- `first(string $key)`: Get the first value from the component's attributes for the given key.
+- `get(string $key)`: Get the value from the component's attributes for the given key.
+- `has(string $key)`: Determine if the component's attributes contain a value for the given key.
+- `hasAny(array $keys)`: Determine if the component's attributes contain a value for any of the given keys.

--- a/src/AppendableAttributeValue.php
+++ b/src/AppendableAttributeValue.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Blade;
+
+use Stringable;
+
+/**
+ * Represents an attribute value that should be appended
+ * to the existing attribute value.
+ */
+final class AppendableAttributeValue implements Stringable
+{
+    public function __construct(private string $value)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -170,4 +170,11 @@ class Attributes implements HtmlableInterface, IteratorAggregate
 
         return $this;
     }
+
+    public function first(): static
+    {
+        $this->attributes = array_slice($this->attributes, 0, 1, true);
+
+        return $this;
+    }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -156,4 +156,18 @@ class Attributes implements HtmlableInterface, IteratorAggregate
 
         return $this;
     }
+
+    public function whereStartsWith(string $needle): static
+    {
+        $this->filter(fn (string $key) => str_starts_with($key, $needle));
+
+        return $this;
+    }
+
+    public function whereDoesntStartWith(string $needle): static
+    {
+        $this->filter(fn (string $key) => !str_starts_with($key, $needle));
+
+        return $this;
+    }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -58,11 +58,7 @@ class Attributes implements HtmlableInterface, IteratorAggregate
     {
         $attributes = is_string($attributes) ? [$attributes] : $attributes;
 
-        foreach ($attributes as $attribute) {
-            unset($this->attributes[$attribute]);
-        }
-
-        return $this;
+        return $this->filter(fn (string $key) => !in_array($key, $attributes));
     }
 
     public function __toString(): string
@@ -148,33 +144,27 @@ class Attributes implements HtmlableInterface, IteratorAggregate
 
     public function filter(callable $callback): static
     {
-        $this->attributes = array_filter(
+        $attributes = array_filter(
             $this->attributes,
             fn (string $value, string $key) => $callback($key, $value),
             ARRAY_FILTER_USE_BOTH
         );
 
-        return $this;
+        return new Attributes($attributes);
     }
 
     public function whereStartsWith(string $needle): static
     {
-        $this->filter(fn (string $key) => str_starts_with($key, $needle));
-
-        return $this;
+        return $this->filter(fn (string $key) => str_starts_with($key, $needle));
     }
 
     public function whereDoesntStartWith(string $needle): static
     {
-        $this->filter(fn (string $key) => !str_starts_with($key, $needle));
-
-        return $this;
+        return $this->filter(fn (string $key) => !str_starts_with($key, $needle));
     }
 
     public function first(): static
     {
-        $this->attributes = array_slice($this->attributes, 0, 1, true);
-
-        return $this;
+        return new static(array_slice($this->attributes, 0, 1, true));
     }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -144,4 +144,16 @@ class Attributes implements HtmlableInterface, IteratorAggregate
 
         return $found;
     }
+
+
+    public function filter(callable $callback): static
+    {
+        $this->attributes = array_filter(
+            $this->attributes,
+            fn (string $value, string $key) => $callback($key, $value),
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        return $this;
+    }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -39,8 +39,16 @@ class Attributes implements HtmlableInterface, IteratorAggregate
 
             if (!isset($this->attributes[$key])) {
                 $this->attributes[$key] = '';
-            } else {
-                $value = " $value";
+            }
+
+            if ($key === 'class') {
+                $this->class($value);
+                continue;
+            }
+
+            if ($value instanceof AppendableAttributeValue) {
+                $this->attributes[$key] = $value . $this->attributes[$key];
+                continue;
             }
 
             $this->attributes[$key] .= $value;
@@ -166,5 +174,16 @@ class Attributes implements HtmlableInterface, IteratorAggregate
     public function first(): static
     {
         return new static(array_slice($this->attributes, 0, 1, true));
+    }
+
+    /**
+     * Prepends a value to the attribute.
+     *
+     * @param string $value
+     * @return AppendableAttributeValue
+     */
+    public function prepends(string $value): AppendableAttributeValue
+    {
+        return new AppendableAttributeValue($value);
     }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -90,7 +90,7 @@ class Attributes implements HtmlableInterface, IteratorAggregate
 
     public function get(string $key)
     {
-        return $this->attributes[toCamelCase($key)] ?? null;
+        return $this->attributes[$key] ?? null;
     }
 
     public function toArray(): array
@@ -116,7 +116,7 @@ class Attributes implements HtmlableInterface, IteratorAggregate
         $keys = is_string($keys) ? [$keys] : $keys;
 
         foreach ($keys as $key) {
-            if (!array_key_exists(toCamelCase($key), $this->attributes)) {
+            if (!array_key_exists($key, $this->attributes)) {
                 $found = false;
                 break;
             }
@@ -136,7 +136,7 @@ class Attributes implements HtmlableInterface, IteratorAggregate
         $found = false;
 
         foreach ($keys as $key) {
-            if (array_key_exists(toCamelCase($key), $this->attributes)) {
+            if (array_key_exists($key, $this->attributes)) {
                 $found = true;
                 break;
             }

--- a/src/ComponentRenderer.php
+++ b/src/ComponentRenderer.php
@@ -101,7 +101,7 @@ class ComponentRenderer
 
 
         foreach ($attributes as $key => $value) {
-            $data[$key] = $value;
+            $data[toCamelCase($key)] = $value;
         }
 
         /**

--- a/src/ComponentRenderer.php
+++ b/src/ComponentRenderer.php
@@ -108,6 +108,7 @@ class ComponentRenderer
          * Setup remaining props and remove
          * them from the attributes array.
          */
+        $propsKeys = [];
         foreach ($component->props as $key => $prop) {
             if (is_int($key)) {
                 $key = $prop;
@@ -118,13 +119,10 @@ class ComponentRenderer
                 $data[$key] = $prop;
             }
 
-            if ($attributes->has($key)) {
-                $attributes->except($key);
-            }
+            $propsKeys[] = $key;
         }
 
-
-        $data['attributes'] = $attributes;
+        $data['attributes'] = $attributes->except($propsKeys);;
         $data['slot'] = $component->slot;
         $data['component_renderer'] = $this;
 

--- a/src/ComponentTagsCompiler.php
+++ b/src/ComponentTagsCompiler.php
@@ -85,7 +85,7 @@ class ComponentTagsCompiler
             )/x
             REGEX,
             function ($matches) {
-                $name = $this->toCamelCase($matches['name']);
+                $name = $matches['name'];
                 $value = $matches['value'] ?? null;
 
                 /**

--- a/tests/ComponentAttributeBagTest.php
+++ b/tests/ComponentAttributeBagTest.php
@@ -188,6 +188,19 @@ class ComponentAttributeBagTest extends TestCase
         );
     }
 
+    public function testPrependsMethod(): void
+    {
+        $this->createComponent(
+            "alert",
+            '<div {{ $attributes->merge( ["aria-label" => $attributes->prepends("hello ")] ) }}></div>'
+        );
+
+        $this->assertSame(
+            "<div aria-label='hello Clicky ti click'></div>",
+            $this->renderBlade('<x-alert aria-label="Clicky ti click"/>')
+        );
+    }
+
     public function testMultiWordAttributes(): void
     {
         $this->createComponent(

--- a/tests/ComponentAttributeBagTest.php
+++ b/tests/ComponentAttributeBagTest.php
@@ -148,4 +148,30 @@ class ComponentAttributeBagTest extends TestCase
             $this->renderBlade('<x-alert type="warning" data-type-full="alert-warning" aria-label="Clicky ti click"/>')
         );
     }
+
+    public function testWhereStartsWithMethod()
+    {
+        $this->createComponent(
+            'alert',
+            '<div {{ $attributes->whereStartsWith("type") }}></div>'
+        );
+
+        $this->assertSame(
+            "<div type='warning'></div>",
+            $this->renderBlade('<x-alert type="warning" data-type-full="alert-warning" aria-label="Clicky ti click"/>')
+        );
+    }
+
+    public function testDoesntWhereStartWithMethod()
+    {
+        $this->createComponent(
+            'alert',
+            '<div {{ $attributes->whereDoesntStartWith("type") }}></div>'
+        );
+
+        $this->assertSame(
+            "<div color='alert-warning' label='Clicky ti click'></div>",
+            $this->renderBlade('<x-alert type="warning" color="alert-warning" label="Clicky ti click"/>')
+        );
+    }
 }

--- a/tests/ComponentAttributeBagTest.php
+++ b/tests/ComponentAttributeBagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Blade\Attributes;
 use PHPUnit\Framework\TestCase;
 
 class ComponentAttributeBagTest extends TestCase
@@ -212,5 +213,32 @@ class ComponentAttributeBagTest extends TestCase
             "<div aria-label='Clicky ti click'></div>",
             $this->renderBlade('<x-alert aria-label="Clicky ti click"/>')
         );
+    }
+
+
+    public function testMergeDoesntMutateOriginalAttributeBag(): void
+    {
+        $original = ['data-first-name' => 'Maria'];
+
+        $attributes = new Attributes($original);
+        $merged = $attributes->merge(['data-last-name' => 'Jose']);
+
+        $this->assertInstanceOf(Attributes::class, $merged);
+        $this->assertNotSame($attributes, $merged);
+
+        $this->assertSame($original, $attributes->toArray());
+    }
+
+    public function testClassDoesntMutateOriginalAttributeBag(): void
+    {
+        $original = ['class' => 'alert'];
+
+        $attributes = new Attributes($original);
+        $classed = $attributes->class('hidden');
+
+        $this->assertInstanceOf(Attributes::class, $classed);
+        $this->assertNotSame($attributes, $classed);
+
+        $this->assertSame($original, $attributes->toArray());
     }
 }

--- a/tests/ComponentAttributeBagTest.php
+++ b/tests/ComponentAttributeBagTest.php
@@ -135,4 +135,17 @@ class ComponentAttributeBagTest extends TestCase
             $this->renderBlade('<x-alert/>')
         );
     }
+
+    public function testFilterMethod()
+    {
+        $this->createComponent(
+            'alert',
+            '<div {{ $attributes->filter(fn (string $key, string $value) => str_contains($key, "type")) }}></div>'
+        );
+
+        $this->assertSame(
+            "<div type='warning'></div>",
+            $this->renderBlade('<x-alert type="warning" data-type-full="alert-warning" aria-label="Clicky ti click"/>')
+        );
+    }
 }

--- a/tests/ComponentAttributeBagTest.php
+++ b/tests/ComponentAttributeBagTest.php
@@ -144,7 +144,7 @@ class ComponentAttributeBagTest extends TestCase
         );
 
         $this->assertSame(
-            "<div type='warning'></div>",
+            "<div type='warning' data-type-full='alert-warning'></div>",
             $this->renderBlade('<x-alert type="warning" data-type-full="alert-warning" aria-label="Clicky ti click"/>')
         );
     }
@@ -185,6 +185,19 @@ class ComponentAttributeBagTest extends TestCase
         $this->assertSame(
             "<div type='warning'></div>",
             $this->renderBlade('<x-alert type="warning" color="alert-warning" label="Clicky ti click"/>')
+        );
+    }
+
+    public function testMultiWordAttributes(): void
+    {
+        $this->createComponent(
+            "alert",
+            '<div {{ $attributes }}></div>'
+        );
+
+        $this->assertSame(
+            "<div aria-label='Clicky ti click'></div>",
+            $this->renderBlade('<x-alert aria-label="Clicky ti click"/>')
         );
     }
 }

--- a/tests/ComponentAttributeBagTest.php
+++ b/tests/ComponentAttributeBagTest.php
@@ -174,4 +174,17 @@ class ComponentAttributeBagTest extends TestCase
             $this->renderBlade('<x-alert type="warning" color="alert-warning" label="Clicky ti click"/>')
         );
     }
+
+    public function testFirstMethod()
+    {
+        $this->createComponent(
+            'alert',
+            '<div {{ $attributes->first() }}></div>'
+        );
+
+        $this->assertSame(
+            "<div type='warning'></div>",
+            $this->renderBlade('<x-alert type="warning" color="alert-warning" label="Clicky ti click"/>')
+        );
+    }
 }

--- a/tests/ComponentTagsTest.php
+++ b/tests/ComponentTagsTest.php
@@ -314,7 +314,7 @@ class ComponentTagsTest extends TestCase
         $this->assertSame(
             "Has Cat Has Dog",
             /**
-             * Remove extra spaces as template 
+             * Remove extra spaces as template
              * will have extra spaces due to formatting
              */
             preg_replace(


### PR DESCRIPTION
Update aims to add support for component attributes methods list mentioned in [Laravel 11x docs](https://laravel.com/docs/11.x/blade#default-merged-attributes), through it is not an exhaustive list but it provides a great starting point covering common use cased.

Goals
- [x] $attributes->merge()
- [x] $attributes->filter()
- [x] $attributes->startsWith() & $attributes->doesntStartWith()
- [x] $attributes->prepends()
- [x] $attributes->first()
- [x] Ensure original attributes immutability on $attributes->merge()
- [x] Ensure original attributes immutability on class.
- [x] Add docs