### PR TITLE
Forward render data to the parent layout in @extends

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -213,7 +213,17 @@ final class Blade
         $template_renderer = $this->templateRenderer;
         $__env = $this;
 
-        include $this->getCachedViewPath($this->compile($viewPath));
+        // Make the render data available to the template-inheritance renderer so
+        // @extends can pass it on to the parent layout. Saved and restored around the
+        // include so nested renders (components, includes) do not clobber it.
+        $previousContextData = $template_renderer->getContextData();
+        $template_renderer->withContextData($data);
+
+        try {
+            include $this->getCachedViewPath($this->compile($viewPath));
+        } finally {
+            $template_renderer->withContextData($previousContextData);
+        }
     }
 
     public function viewExists(string $name): bool

--- a/src/Blade.php
+++ b/src/Blade.php
@@ -213,17 +213,7 @@ final class Blade
         $template_renderer = $this->templateRenderer;
         $__env = $this;
 
-        // Make the render data available to the template-inheritance renderer so
-        // @extends can pass it on to the parent layout. Saved and restored around the
-        // include so nested renders (components, includes) do not clobber it.
-        $previousContextData = $template_renderer->getContextData();
-        $template_renderer->withContextData($data);
-
-        try {
-            include $this->getCachedViewPath($this->compile($viewPath));
-        } finally {
-            $template_renderer->withContextData($previousContextData);
-        }
+        include $this->getCachedViewPath($this->compile($viewPath));
     }
 
     public function viewExists(string $name): bool

--- a/src/CompileAtRules.php
+++ b/src/CompileAtRules.php
@@ -336,7 +336,7 @@ class CompileAtRules
 
     protected function endExtends(): string
     {
-        return "<?php \$template_renderer->output(); ?>";
+        return "<?php \$template_renderer->withDefault(get_defined_vars())->output(); ?>";
     }
 
     protected function compileYield(string $expression): string

--- a/src/TemplateInheritanceRenderer.php
+++ b/src/TemplateInheritanceRenderer.php
@@ -11,6 +11,19 @@ class TemplateInheritanceRenderer
     protected ?array $tempContextData = null;
     protected array $rendered = [];
 
+    /** Data of the current render, forwarded to the parent layout by @extends. */
+    protected array $contextData = [];
+
+    public function withContextData(array $data): void
+    {
+        $this->contextData = $data;
+    }
+
+    public function getContextData(): array
+    {
+        return $this->contextData;
+    }
+
     public function __construct(protected Blade $blade) {}
 
     public function extends(string $template): void
@@ -107,7 +120,7 @@ class TemplateInheritanceRenderer
 
         $this->renderingParentLayout = true;
 
-        echo $this->blade->render($this->template);
+        echo $this->blade->render($this->template, $this->contextData);
     }
 
     public function include(string $template, array $data = [])

--- a/src/TemplateInheritanceRenderer.php
+++ b/src/TemplateInheritanceRenderer.php
@@ -11,19 +11,6 @@ class TemplateInheritanceRenderer
     protected ?array $tempContextData = null;
     protected array $rendered = [];
 
-    /** Data of the current render, forwarded to the parent layout by @extends. */
-    protected array $contextData = [];
-
-    public function withContextData(array $data): void
-    {
-        $this->contextData = $data;
-    }
-
-    public function getContextData(): array
-    {
-        return $this->contextData;
-    }
-
     public function __construct(protected Blade $blade) {}
 
     public function extends(string $template): void
@@ -120,7 +107,10 @@ class TemplateInheritanceRenderer
 
         $this->renderingParentLayout = true;
 
-        echo $this->blade->render($this->template, $this->contextData);
+        $defaultData = $this->tempContextData ?? [];
+        $this->tempContextData = null;
+
+        echo $this->blade->render($this->template, $defaultData);
     }
 
     public function include(string $template, array $data = [])

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -29,6 +29,31 @@ class TemplateInheritanceTest extends TestCase
         );
     }
 
+    public function testExtendsReceivesViewData(): void
+    {
+        $layout = sprintf(self::LAYOUT, '{{ $viewData }}');
+        $this->createTemporaryBladeFile($layout, 'layout');
+
+        $message = 'Data passed to view';
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, $message),
+            $this->renderBlade('@extends("layout")', ['viewData' => $message,])
+        );
+    }
+
+    public function testExtendsReceivesVariablesDefinedInView(): void
+    {
+        $layout = sprintf(self::LAYOUT, '{{ $declaredInView }}');
+        $this->createTemporaryBladeFile($layout, 'layout');
+
+        $message = 'declared in view';
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, $message),
+            $this->renderBlade("@extends('layout') @php \$declaredInView = '$message' @endphp")
+        );
+    }
 
     public function testYieldWithDefaultContent(): void
     {

--- a/tests/TemplateInheritanceTest.php
+++ b/tests/TemplateInheritanceTest.php
@@ -55,6 +55,21 @@ class TemplateInheritanceTest extends TestCase
         );
     }
 
+    public function testIncludeDoesNotPolluteContext(): void
+    {
+        $layout = sprintf(self::LAYOUT, '{{ $pageName }}');
+        $this->createTemporaryBladeFile($layout, 'layout');
+
+        $this->createTemporaryBladeFile('@php $pageName = "About us" @endphp', 'subview');
+
+        $pageName = 'Homepage';
+
+        $this->assertSame(
+            sprintf(self::LAYOUT, $pageName),
+            $this->renderBlade("@extends('layout') @include('subview')", ['pageName' => $pageName])
+        );
+    }
+
     public function testYieldWithDefaultContent(): void
     {
         $this->createTemporaryBladeFile(


### PR DESCRIPTION
When a view uses @extends, output() renders the parent layout with no data, so the layout cannot read any of the variables passed to the child render. This forwards the render data to the parent, saved and restored around each render so nested components and includes do not clobber it. This is only a quick fix and is waiting for a better idea.