### PR TITLE
Fixed: Short echo tags <?= in <?php ?> rewrite #62

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -109,6 +109,7 @@ class Compiler
             if (is_array($token)) {
                 $template .= match ($token[0]) {
                     T_OPEN_TAG => "@php",
+                    T_OPEN_TAG_WITH_ECHO => "@php echo ",
                     T_CLOSE_TAG => "@endphp",
                     default => $token[1],
                 };

--- a/tests/PhpBlockTest.php
+++ b/tests/PhpBlockTest.php
@@ -81,4 +81,77 @@ class PhpBlockTest extends TestCase
             $this->assertEmpty($this->renderBlade($template));
         }
     }
+
+    public function testShortEchoTagsAreAllowed(): void
+    {
+        $templates = [
+            // Short echo on its own.
+            [
+                'blade' => '<?= "Hello" ?>',
+                'output' => 'Hello',
+            ],
+
+            // Short echo immediately followed by inline HTML: the closing tag
+            // must not become a stray @endphp while the opening tag survives.
+            [
+                'blade' => '<?= "x" ?>y',
+                'output' => 'xy'
+            ],
+
+            // Short echo inside an HTML attribute value.
+            [
+                'blade' => '<a href="<?= "x" ?>y">z</a>',
+                'output' => '<a href="xy">z</a>',
+            ],
+
+            // Short echo reading passed data, with a trailing element.
+            [
+                'blade' => '<div><?= $value ?>tail</div>',
+                'output' => '<div>Valuetail</div>',
+            ],
+
+            // Consecutive short echoes.
+            [
+                'blade' => '<?= "a" ?><?= "b" ?>',
+                'output' => 'ab',
+            ],
+
+            // Short and long echo mixed in one template.
+            [
+                'blade' => '<?= "a" ?>-<?php echo "b"; ?>',
+                'output' => 'a-b',
+            ],
+        ];
+
+        foreach ($templates as $template) {
+            $this->assertSame(
+                $template['output'],
+                $this->renderBlade(
+                    $template['blade'],
+                    ['value' => 'Value'],
+                ),
+            );
+        }
+    }
+
+    public function testDoesNotCompileDirectivesInShortEcho(): void
+    {
+        $templates = [
+            [
+                'blade' => '<?= "{{ 1 + 1 }}" ?>',
+                'output' => '{{ 1 + 1 }}',
+            ],
+            [
+                'blade' => '<?= "@if(true) @endif" ?>',
+                'output' => '@if(true) @endif',
+            ],
+        ];
+
+        foreach ($templates as $template) {
+            $this->assertSame(
+                $template['output'],
+                $this->renderBlade($template['blade']),
+            );
+        }
+    }
 }


### PR DESCRIPTION
#61 rewrites `<?php` and `?>` into `@php`/`@endphp` but leaves `<?=` untouched, so a short echo tag kept its opening tag literal while its `?>` became `@endphp`. That produced a stray `@endphp` (ParseError) and let Blade directives compile inside the echoed string.

This maps `T_OPEN_TAG_WITH_ECHO` to `@php echo` so `<?=` compiles like `<?php echo`, with tests covering inline, attribute, consecutive and mixed short echoes.

Fixes #62.
